### PR TITLE
requirements: replace lz4a with lz4 to fix build error when >= python3.11

### DIFF
--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,6 +1,6 @@
 requests
 protobuf>=3.4.0
 six
-lz4a
+lz4
 python-dateutil
 python-snappy

--- a/requirements-py26.txt
+++ b/requirements-py26.txt
@@ -1,6 +1,6 @@
 requests
 protobuf<=3.4.0
 six
-lz4a
+lz4
 python-dateutil
 python-snappy

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,6 +1,6 @@
 requests
 protobuf>=3.4.0
 six
-lz4a
+lz4
 python-dateutil
 python-snappy

--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,14 @@ requirements_py3 = [
     'six',
     'requests',
     'protobuf>=3.4.0,<4.0.0',
-    'lz4a==0.7.0',
+    'lz4',
 ]
 
 requirements_py2 = [
     'six==1.14.0',
     'requests==2.23.0',
     'protobuf<=3.4.0',
-    'lz4a==0.7.0',
+    'lz4',
 ]
 
 requirements = []

--- a/tencentcloud/log/logclient.py
+++ b/tencentcloud/log/logclient.py
@@ -25,17 +25,20 @@ if six.PY3:
     xrange = range
 
 try:
-    import lz4
+    try:
+        import lz4.block as lz4
+    except ImportError:
+        import lz4
 
-    if not hasattr(lz4, 'loads') or not hasattr(lz4, 'dumps'):
+    if not hasattr(lz4, 'decompress') or not hasattr(lz4, 'compress'):
         lz4 = None
     else:
         def lz_decompress(raw_size, data):
-            return lz4.loads(struct.pack('<I', raw_size) + data)
+            return lz4.decompress(struct.pack('<I', raw_size) + data)
 
 
         def lz_compresss(data):
-            return lz4.dumps(data)[4:]
+            return lz4.compress(data)[4:]
 
 except ImportError:
     lz4 = None


### PR DESCRIPTION
lz4a is deprecated and replaced by lz4.